### PR TITLE
fix typo 'AUTHOR' to 'AUTHOR_EMAIL'

### DIFF
--- a/src/eatpy/default_files/package/setup_cfg.py
+++ b/src/eatpy/default_files/package/setup_cfg.py
@@ -4,7 +4,7 @@ name = {PROJECT}
 description = {DESCRIPTION}
 long_description = {LONG_DESCRIPTION}
 author = {AUTHOR}
-author_email = {AUTHOR}
+author_email = {AUTHOR_EMAIL}
 keywords = {KEYWORDS}
 license = {LICENSE}
 


### PR DESCRIPTION
fix typo of `setup_cfg.py` of package 